### PR TITLE
added `members` attribute to `resource_user_group` to set members

### DIFF
--- a/docs/data-sources/user_group.md
+++ b/docs/data-sources/user_group.md
@@ -34,5 +34,6 @@ resource "jumpcloud_user_group_association" "example" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `members` (Map of String) This is a set of user emails associated with this group
 
 

--- a/docs/resources/user_group.md
+++ b/docs/resources/user_group.md
@@ -32,6 +32,7 @@ output "group_id" {
 ### Optional
 
 - `attributes` (Map of String)
+- `members` (Map of String) This is a set of user emails associated with this group
 
 ### Read-Only
 

--- a/jumpcloud/data_source_user_group.go
+++ b/jumpcloud/data_source_user_group.go
@@ -20,6 +20,14 @@ func dataSourceJumpCloudUserGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"members": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "This is a set of user emails associated with this group",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -46,6 +54,18 @@ func dataSourceJumpCloudUserGroupRead(d *schema.ResourceData, m interface{}) err
 	for _, group := range groups {
 		if group.Name == groupName {
 			d.SetId(group.Id)
+
+			memberIDs, err := getUserGroupMemberIDs(client, d.Id())
+			if err != nil {
+				return err
+			}
+			memberEmails, err := userIDsToEmails(config, memberIDs)
+			if err != nil {
+				return err
+			}
+			if err := d.Set("members", memberEmails); err != nil {
+				return err
+			}
 			return nil
 		}
 	}

--- a/jumpcloud/data_source_user_group_test.go
+++ b/jumpcloud/data_source_user_group_test.go
@@ -21,6 +21,9 @@ func TestAccDataSourceJumpCloudUserGroup_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.jumpcloud_user_group.test_group", "id"),
 					resource.TestCheckResourceAttr("data.jumpcloud_user_group.test_group", "group_name", rName),
+					resource.TestCheckResourceAttr("data.jumpcloud_user_group.test_group", "members.#", "2"),
+					resource.TestCheckResourceAttr("data.jumpcloud_user_group.test_group", "members.0", fmt.Sprintf("%s1@testorg.com", rName)),
+					resource.TestCheckResourceAttr("data.jumpcloud_user_group.test_group", "members.1", fmt.Sprintf("%s3@testorg.com", rName)),
 				),
 			},
 		},
@@ -29,8 +32,35 @@ func TestAccDataSourceJumpCloudUserGroup_basic(t *testing.T) {
 
 func testAccDataSourceJumpCloudUserGroupConfig(groupName string) string {
 	return fmt.Sprintf(`
+resource "jumpcloud_user" "test_user1" {
+  username = "%[1]s1"
+  email = "%[1]s1@testorg.com"
+  firstname = "Firstname"
+  lastname = "Lastname"
+  enable_mfa = true
+}
+resource "jumpcloud_user" "test_user2" {
+  username = "%[1]s2"
+  email = "%[1]s2@testorg.com"
+  firstname = "Firstname"
+  lastname = "Lastname"
+  enable_mfa = true
+}
+resource "jumpcloud_user" "test_user3" {
+  username = "%[1]s3"
+  email = "%[1]s3@testorg.com"
+  firstname = "Firstname"
+  lastname = "Lastname"
+  enable_mfa = true
+}
+
 resource "jumpcloud_user_group" "test_group" {
-  name = "%s"
+  name = "%[1]s"
+
+  members = [
+    jumpcloud_user.test_user1.email,
+    jumpcloud_user.test_user3.email,
+  ]
 }
 
 data "jumpcloud_user_group" "test_group" {

--- a/jumpcloud/resource_user_group.go
+++ b/jumpcloud/resource_user_group.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
-
 	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"net/http"
+	"slices"
 )
 
 func resourceUserGroup() *schema.Resource {
@@ -48,6 +48,16 @@ func resourceUserGroup() *schema.Resource {
 					},
 				},
 			},
+			"members": {
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: EqualIgnoringOrder,
+				Description:      "This is a set of user emails associated with this group",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -79,6 +89,18 @@ func resourceUserGroupCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.SetId(group.Id)
+
+	memberIds, err := userEmailsToIDs(config, d.Get("members").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	for _, memberId := range memberIds {
+		err := manageGroupMember(client, d, memberId, "add")
+		if err != nil {
+			return err
+		}
+	}
 	return resourceUserGroupRead(d, m)
 }
 
@@ -105,6 +127,19 @@ func resourceUserGroupRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	if err := d.Set("attributes", flattenAttributes(&group.Attributes)); err != nil {
+		return err
+	}
+
+	client := jcapiv2.NewAPIClient(config)
+	memberIDs, err := getUserGroupMemberIDs(client, d.Id())
+	if err != nil {
+		return err
+	}
+	memberEmails, err := userIDsToEmails(config, memberIDs)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("members", memberEmails); err != nil {
 		return err
 	}
 
@@ -163,6 +198,36 @@ func resourceUserGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		// TODO: sort out error essentials
 		return fmt.Errorf("error deleting user group:%s; response = %+v", err, res)
+	}
+
+	oldMemberIDs, err := getUserGroupMemberIDs(client, d.Id())
+	if err != nil {
+		return err
+	}
+
+	newMemberIDs, err := userEmailsToIDs(config, d.Get("members").([]interface{}))
+	if err != nil {
+		return err
+	}
+
+	//add any new users
+	for _, newMemberID := range newMemberIDs {
+		if !slices.Contains(oldMemberIDs, newMemberID) {
+			err := manageGroupMember(client, d, newMemberID, "add")
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	//remove any old users
+	for _, oldMemberID := range oldMemberIDs {
+		if !slices.Contains(newMemberIDs, oldMemberID) {
+			err := manageGroupMember(client, d, oldMemberID, "remove")
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return resourceUserGroupRead(d, m)

--- a/jumpcloud/resource_user_group_test.go
+++ b/jumpcloud/resource_user_group_test.go
@@ -1,9 +1,12 @@
 package jumpcloud
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"sort"
 	"testing"
 
 	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
@@ -18,32 +21,138 @@ func TestAccUserGroup(t *testing.T) {
 	posixName := acctest.RandStringFromCharSet(10, acctest.CharSetAlpha)
 	gid := acctest.RandIntRange(1, 1000)
 
+	emails := make([]string, 123)
+	for i := 0; i < 123; i++ {
+		emails[i] = fmt.Sprintf("%s%d@testorg.com", rName, i)
+	}
+	sort.Strings(emails)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccUserGroup(rName, gid, posixName),
+				Config: testAccUserGroupCreate(rName, gid, posixName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "name", rName),
 					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group",
 						"attributes.posix_groups", fmt.Sprintf("%d:%s", gid, posixName)),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.#", "123"),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.0", emails[0]),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.60", emails[60]),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.99", emails[99]),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.100", emails[100]),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.122", emails[122]),
+				),
+			},
+			{ //check update works
+				Config: testAccUserGroupUpdate(rName, gid, posixName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.#", "2"),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.0", fmt.Sprintf("%s1@testorg.com", rName)),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.1", fmt.Sprintf("%s2@testorg.com", rName)),
+				),
+			},
+			{ //add a user to the group via the api, then check the plan complains
+				PreConfig:          addGroupMemberViaAPI(t, rName),
+				Config:             testAccUserGroupUpdate(rName, gid, posixName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			{ //remove the extra user
+				Config: testAccUserGroupUpdate(rName, gid, posixName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.#", "2"),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.0", fmt.Sprintf("%s1@testorg.com", rName)),
+					resource.TestCheckResourceAttr("jumpcloud_user_group.test_group", "members.1", fmt.Sprintf("%s2@testorg.com", rName)),
 				),
 			},
 		},
 	})
 }
 
-func testAccUserGroup(name string, gid int, posixName string) string {
+func testAccUserGroupCreate(name string, gid int, posixName string) string {
 	return fmt.Sprintf(`
+		resource "jumpcloud_user" "test_users" {
+			count = 123 #test pagination on group membership
+
+			username = "%[1]s${count.index}"
+			email = "%[1]s${count.index}@testorg.com"
+			firstname = "Firstname"
+			lastname = "Lastname"
+			enable_mfa = true
+		}
 		resource "jumpcloud_user_group" "test_group" {
-    		name = "%s"
+    		name = "%[1]s"
 			attributes = {
-				posix_groups = "%d:%s"
+				posix_groups = "%[2]d:%[3]s"
 			}
+			members = jumpcloud_user.test_users[*].email
 		}`, name, gid, posixName,
 	)
+}
+func testAccUserGroupUpdate(name string, gid int, posixName string) string {
+	return fmt.Sprintf(`
+		resource "jumpcloud_user" "test_users" {
+			count = 123 #test pagination on group membership
+
+			username = "%[1]s${count.index}"
+			email = "%[1]s${count.index}@testorg.com"
+			firstname = "Firstname"
+			lastname = "Lastname"
+			enable_mfa = true
+		}
+		resource "jumpcloud_user_group" "test_group" {
+    		name = "%[1]s"
+			attributes = {
+				posix_groups = "%[2]d:%[3]s"
+			}
+			members = [
+				jumpcloud_user.test_users[2].email,
+				jumpcloud_user.test_users[1].email,
+			]
+		}`, name, gid, posixName,
+	)
+}
+
+func addGroupMemberViaAPI(t *testing.T, name string) func() {
+	return func() {
+		config := jcapiv2.NewConfiguration()
+		config.AddDefaultHeader("x-api-key", os.Getenv("JUMPCLOUD_API_KEY"))
+		client := jcapiv2.NewAPIClient(config)
+
+		groups, _, err := client.UserGroupsApi.GroupsUserList(context.Background(), "", "", map[string]interface{}{
+			"filter": []string{fmt.Sprintf(`name:eq:%s`, name)},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		email := make([]interface{}, 1)
+		email[0] = fmt.Sprintf("%s43@testorg.com", name)
+
+		ids, err := userEmailsToIDs(config, email)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := jcapiv2.UserGroupMembersReq{
+			Op:    "add",
+			Type_: "user",
+			Id:    ids[0],
+		}
+
+		req := map[string]interface{}{
+			"body": payload,
+		}
+
+		_, err = client.UserGroupMembersMembershipApi.GraphUserGroupMembersPost(
+			context.TODO(), groups[0].Id, "", "", req)
+
+		if err != nil {
+			t.Fatal(fmt.Sprintf("error adding user to group via api. group_id: %s, user_id: %s, error: %s", groups[0].Id, ids[0], err))
+		}
+	}
 }
 
 func TestResourceUserGroup(t *testing.T) {

--- a/jumpcloud/utils.go
+++ b/jumpcloud/utils.go
@@ -1,8 +1,18 @@
 package jumpcloud
 
 import (
-	"github.com/go-resty/resty/v2"
+	"context"
+	"fmt"
 	"log"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	jcapiv1 "github.com/TheJumpCloud/jcapi-go/v1"
+	jcapiv2 "github.com/TheJumpCloud/jcapi-go/v2"
+	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 // Gets an application's metadata XML for SAML authentication
@@ -37,4 +47,164 @@ func stringInSlice(a string, list []string) bool {
 		}
 	}
 	return false
+}
+
+func getUserGroupMemberIDs(client *jcapiv2.APIClient, groupID string) ([]string, error) {
+	var userIds []string
+	for i := 0; ; i++ {
+		optionals := map[string]interface{}{
+			"groupId": groupID,
+			"limit":   int32(100),
+			"skip":    int32(i * 100),
+		}
+
+		graphconnect, res, err := client.UserGroupMembersMembershipApi.GraphUserGroupMembersList(
+			context.TODO(), groupID, "", "", optionals)
+		if err != nil {
+			return nil, fmt.Errorf("error getting group members for group id %s, error:%s; response = %+v", groupID, err, res)
+		}
+
+		for _, v := range graphconnect {
+			userIds = append(userIds, v.To.Id)
+		}
+
+		if len(graphconnect) < 100 {
+			break
+		} else {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	return userIds, nil
+}
+
+func userIDsToEmails(configv2 *jcapiv2.Configuration, userIDs []string) ([]string, error) {
+	emails := make([]string, len(userIDs))
+
+	if len(userIDs) == 0 {
+		return emails, nil
+	}
+
+	configv1 := convertV2toV1Config(configv2)
+	client := jcapiv1.NewAPIClient(configv1)
+
+	for i := 0; ; i++ {
+		users, res, err := client.SystemusersApi.SystemusersList(context.TODO(), "", "", map[string]interface{}{
+			"filter": "_id:$in:" + strings.Join(userIDs[:], "|"),
+			"limit":  int32(100),
+			"skip":   int32(i * 100),
+			"fields": "email",
+			"sort":   "email",
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("error loading user emails from IDs: %s, i:%d, error:%s; response:%+v", userIDs, i, err, res)
+		}
+
+		for j, result := range users.Results {
+			emails[j+(i*100)] = result.Email
+		}
+
+		if len(users.Results) < 100 {
+			break
+		} else {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	return emails, nil
+}
+
+func userEmailsToIDs(configv2 *jcapiv2.Configuration, userEmailsInterface []interface{}) ([]string, error) {
+	userEmails := make([]string, len(userEmailsInterface))
+	for i, userEmail := range userEmailsInterface {
+		userEmails[i] = userEmail.(string)
+	}
+
+	ids := make([]string, len(userEmailsInterface))
+
+	if len(userEmails) == 0 {
+		return ids, nil
+	}
+
+	configv1 := convertV2toV1Config(configv2)
+	client := jcapiv1.NewAPIClient(configv1)
+
+	for i := 0; ; i++ {
+		users, res, err := client.SystemusersApi.SystemusersList(context.TODO(), "", "", map[string]interface{}{
+			"filter": "email:$in:" + strings.Join(userEmails[:], "|"),
+			"limit":  int32(100),
+			"skip":   int32(i * 100),
+			"fields": "_id",
+			"sort":   "_id",
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("error loading user IDs from emails:%s; response = %+v", err, res)
+		}
+
+		for j, result := range users.Results {
+			ids[j+(i*100)] = result.Id
+		}
+
+		if len(users.Results) < 100 {
+			break
+		} else {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	return ids, nil
+}
+
+func manageGroupMember(client *jcapiv2.APIClient, d *schema.ResourceData, memberID string, action string) error {
+	payload := jcapiv2.UserGroupMembersReq{
+		Op:    action,
+		Type_: "user",
+		Id:    memberID,
+	}
+
+	req := map[string]interface{}{
+		"body": payload,
+	}
+
+	res, err := client.UserGroupMembersMembershipApi.GraphUserGroupMembersPost(
+		context.TODO(), d.Id(), "", "", req)
+
+	if err != nil {
+		return fmt.Errorf("error managing group member, action: %s, member id:%s, error: %s; response = %+v", action, memberID, err, res)
+	}
+	return nil
+}
+
+// https://github.com/rootlyhq/terraform-provider-rootly/blob/99175a7ab4e154793ea8a8710d329a3f48eb0c90/tools/ignore_array_order.go#L12
+func EqualIgnoringOrder(key, oldValue, newValue string, d *schema.ResourceData) bool {
+	// The key is a path not the list itself, e.g. "events.0"
+	lastDotIndex := strings.LastIndex(key, ".")
+	if lastDotIndex != -1 {
+		key = string(key[:lastDotIndex])
+	}
+	oldData, newData := d.GetChange(key)
+	if oldData == nil || newData == nil {
+		return false
+	}
+	oldArray := oldData.([]interface{})
+	newArray := newData.([]interface{})
+	if len(oldArray) != len(newArray) {
+		// Items added or removed, always detect as changed
+		return false
+	}
+
+	// Convert data to string arrays
+	oldItems := make([]string, len(oldArray))
+	newItems := make([]string, len(newArray))
+	for i, oldItem := range oldArray {
+		oldItems[i] = oldItem.(string)
+	}
+	for j, newItem := range newArray {
+		newItems[j] = newItem.(string)
+	}
+	// Ensure consistent sorting before comparison, to suppress unnecessary change detections
+	sort.Strings(oldItems)
+	sort.Strings(newItems)
+	return reflect.DeepEqual(oldItems, newItems)
 }


### PR DESCRIPTION
so can set members when creating the group, and keep the member list in sync with terraform. E.g. if someone adds a user directly in jumpcloud, rerunning the terraform will remove them

test output

```
go build -o terraform-provider-jumpcloud
TF_ACC=true go test -v ./...
?   	github.com/cheelim1/terraform-provider-jumpcloud	[no test files]
=== RUN   TestAccDataSourceJumpCloudUserGroup_basic
--- PASS: TestAccDataSourceJumpCloudUserGroup_basic (6.17s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccUserGroup
--- PASS: TestAccUserGroup (102.00s)
=== RUN   TestResourceUserGroup
=== RUN   TestResourceUserGroup/TestTrueUserGroupRead
--- PASS: TestResourceUserGroup (0.00s)
    --- PASS: TestResourceUserGroup/TestTrueUserGroupRead (0.00s)
```

The TestAccUserGroup is slow because it makes 123 users and adds them to a group, then removes them. Making that many users isn't quick, and if you run these tests a lot one after the other causes a temporary outage on the jumpcloud api :grimacing: 